### PR TITLE
Fixed logo scaling 

### DIFF
--- a/collective/responsivetheme/skins/collective_responsivetheme_styles/responsivetheme.css
+++ b/collective/responsivetheme/skins/collective_responsivetheme_styles/responsivetheme.css
@@ -34,3 +34,12 @@ button.navigation-button {
     border:1px solid #999999;
     }
     
+@media screen and (max-width: 610px) {
+    #portal-logo {
+        width: 100%;
+    }
+    
+    #logo {
+        width: 22.75% !important;
+    }
+}

--- a/collective/responsivetheme/templates/plone.app.layout.viewlets.logo.pt
+++ b/collective/responsivetheme/templates/plone.app.layout.viewlets.logo.pt
@@ -1,5 +1,5 @@
 <div metal:define-macro="portal_logo"
-     tal:attributes="class string:cell width-1:4 position-0" id="logo"> 
+     tal:attributes="class string:cell position-0" id="logo"> 
 <a id="portal-logo"
    title="Home"
    accesskey="1"

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -1,7 +1,7 @@
 Changelog
 =========
-1.3.2 (2012-11-30)
-------------------
+1.4-colliberty (2013-07-08)
+---------------------------
 - Made viewportchange.js default to false in the jsregistry.xml since the scaling that was happening was not the viewport itself but gravity of all things after talking to Ethan Marcotte and Luke W.  
 
 1.3.1 (2012-11-20)

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -1,5 +1,11 @@
 Changelog
 =========
+1.4 (unreleased)
+----------------
+
+- Nothing changed yet.
+
+
 1.4-colliberty (2013-07-08)
 ---------------------------
 - Made viewportchange.js default to false in the jsregistry.xml since the scaling that was happening was not the viewport itself but gravity of all things after talking to Ethan Marcotte and Luke W.  

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import os
 
-version = '1.4-colliberty'
+version = '1.4.dev0'
 
 setup(name='collective.responsivetheme',
       version=version,

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import os
 
-version = '1.3.2'
+version = '1.4-colliberty'
 
 setup(name='collective.responsivetheme',
       version=version,


### PR DESCRIPTION
The logo would only scale on Chrome, and then it would scale wrongly if the viewport was big. I fixed this so it will be full size when the viewport > 610px and scale nicely when it's < 610px. Tested on Chromium 28, FF 22 and IE 10.
